### PR TITLE
Add setURL method and include hovered classes as element option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xyz-digital/dom",
-  "version": "0.0.2",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xyz-digital/dom",
-      "version": "0.0.2",
+      "version": "0.0.7",
       "license": "ISC",
       "devDependencies": {
         "prettier": "^2.8.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xyz-digital/dom",
-  "version": "0.0.7",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xyz-digital/dom",
-      "version": "0.0.7",
+      "version": "0.0.2",
       "license": "ISC",
       "devDependencies": {
         "prettier": "^2.8.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xyz-digital/dom",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "DOM helpers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/components/Element.ts
+++ b/src/components/Element.ts
@@ -17,12 +17,13 @@ type ElementProps = {
   attr?: ElementAttributes;
   id?: string;
   class?: string;
+  classOnHover?: string;
   styles?: Partial<CSSStyleDeclaration>;
 };
 
 export function Element(props: ElementProps) {
   const el = document.createElement(props.tag);
-  const { id, attr, styles } = props;
+  const { id, attr, styles, classOnHover } = props;
 
   if (id) {
     el.setAttribute('id', id);
@@ -40,6 +41,12 @@ export function Element(props: ElementProps) {
 
   if (styles) {
     setStyle(el, styles);
+  }
+
+  if (classOnHover) {
+    const classListOnHover = classOnHover.split(' ');
+    el.onmouseover = () => el.classList.add(...classListOnHover);
+    el.onmouseout = () => el.classList.remove(...classListOnHover);
   }
 
   return el;

--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -1,18 +1,12 @@
 import { Element, ElementAttributes } from './Element';
 
 interface InputAttributes extends ElementAttributes {
+  autocomplete?: 'on' | 'off';
   checked?: boolean;
   disabled?: boolean;
   placeholder?: string;
   required?: boolean;
-  type?:
-    | 'text'
-    | 'date'
-    | 'time'
-    | 'checkbox'
-    | 'datetime-local'
-    | 'password'
-    | 'radio';
+  type?: 'checkbox' | 'date' | 'datetime-local' | 'password' | 'radio' | 'search' | 'time' | 'text';
   value?: string;
   onkeyup?: (e: KeyboardEvent) => void;
 }

--- a/src/components/Input.ts
+++ b/src/components/Input.ts
@@ -6,7 +6,7 @@ interface InputAttributes extends ElementAttributes {
   disabled?: boolean;
   placeholder?: string;
   required?: boolean;
-  type?: 'checkbox' | 'date' | 'datetime-local' | 'password' | 'radio' | 'search' | 'time' | 'text';
+  type?: 'checkbox' | 'date' | 'datetime-local' | 'password' | 'radio' | 'search' | 'submit' | 'tel' | 'text' | 'time';
   value?: string;
   onkeyup?: (e: KeyboardEvent) => void;
 }

--- a/src/components/P.ts
+++ b/src/components/P.ts
@@ -1,0 +1,15 @@
+import { Element, ElementAttributes } from './Element';
+
+type PProps = {
+  attr?: ElementAttributes;
+  class?: string;
+  id?: string;
+  styles?: Partial<CSSStyleDeclaration>;
+};
+
+export function P(props?: PProps) {
+  return Element({
+    tag: 'p',
+    ...props,
+  });
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ export { H1 } from './H1';
 export { H3 } from './H3';
 export { Input } from './Input';
 export { Label } from './Label';
+export { P } from './P';
 export { Span } from './Span';
 export { Table, Td, Th, Tr } from './Table';
 export { Textarea } from './Textarea';

--- a/src/utils/HistoryUtils.ts
+++ b/src/utils/HistoryUtils.ts
@@ -1,0 +1,4 @@
+export function setURL(url: string) {
+  history.pushState({}, '', url);
+  window.dispatchEvent(new Event('popstate'));
+}


### PR DESCRIPTION
Changes: 
- Added history utils to change URL without refreshing page
- Added `classOnHover` to add classes that should be added or removed whenever an element is/isn't hovered
- Added autocomplete, type=search,  type=tel and  type=submit in the Input Attributes
- Added `<p></p>` paragraph element